### PR TITLE
Round inner fill corners

### DIFF
--- a/Bar.js
+++ b/Bar.js
@@ -116,6 +116,7 @@ export default class ProgressBar extends Component {
     };
     const progressStyle = {
       backgroundColor: color,
+      borderRadius,
       height,
       width: this.state.progress.interpolate({
         inputRange: [0, 1],


### PR DESCRIPTION
Allow the inner container(fill) to round corners just like the parent progress container or else it will overflow.