### PR TITLE
Bar.js Syntax Fix

### DIFF
--- a/Bar.js
+++ b/Bar.js
@@ -102,7 +102,7 @@ export default class ProgressBar extends Component {
       style,
       unfilledColor,
       width,
-      ...restProps,
+      ...restProps
     } = this.props;
 
     const innerWidth = width - borderWidth * 2;


### PR DESCRIPTION
Prevent `Syntax Error react-native-progress/Bar.js: A trailing comma is not permitted after the rest element` see https://github.com/facebook/react-native/issues/10199
