### PR TITLE
Add Bar parameter to apply inner border

### DIFF
--- a/Bar.js
+++ b/Bar.js
@@ -26,6 +26,7 @@ export default class ProgressBar extends Component {
     style: View.propTypes.style,
     unfilledColor: PropTypes.string,
     width: PropTypes.number,
+    applyInnerBorder: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -37,6 +38,7 @@ export default class ProgressBar extends Component {
     indeterminate: false,
     progress: 0,
     width: 150,
+    applyInnerBorder: false,
   };
 
   constructor(props) {
@@ -109,6 +111,7 @@ export default class ProgressBar extends Component {
       style,
       unfilledColor,
       width,
+      applyInnerBorder,
       ...restProps
     } = this.props;
 
@@ -123,6 +126,7 @@ export default class ProgressBar extends Component {
     };
     const progressStyle = {
       backgroundColor: color,
+      borderRadius: applyInnerBorder ? borderRadius : 0,
       height,
       width: innerWidth,
       transform: [{

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ All of the props under *Properties* in addition to the following:
 |**`width`**|Full width of the progress bar. |`150`|
 |**`height`**|Height of the progress bar. |`6`|
 |**`borderRadius`**|Rounding of corners, set to `0` to disable. |`4`|
+|**`applyInnerBorder`**|Applies the border radius to the inner filled bar. |`false`|
 
 ### `Progress.Circle`
 


### PR DESCRIPTION
I added a parameter to get a border radius on the inner part of the progress bar (the filled part). Would that be interesting for you to integrate?