### PR TITLE
Allow inner node instead of text inside circle

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -35,6 +35,7 @@ export class ProgressCircle extends Component {
     children: React.PropTypes.node,
     direction: PropTypes.oneOf(['clockwise', 'counter-clockwise']),
     formatText: PropTypes.func,
+    innerNode: PropTypes.func,
     indeterminate: PropTypes.bool,
     progress: PropTypes.oneOfType([
       PropTypes.number,
@@ -86,6 +87,7 @@ export class ProgressCircle extends Component {
       children,
       direction,
       formatText,
+      innerNode,
       indeterminate,
       progress,
       rotation,
@@ -174,15 +176,18 @@ export class ProgressCircle extends Component {
               justifyContent: 'center',
             }}
           >
-            <Text
-              style={[{
-                color,
-                fontSize: textSize / 4.5,
-                fontWeight: '300',
-              }, textStyle]}
-            >
-              {formatText(progressValue)}
-            </Text>
+            {innerNode ? innerNode(progressValue) : (
+              <Text
+                style={
+                  [{
+                    color,
+                    fontSize: textSize / 4.5,
+                    fontWeight: '300',
+                  }, textStyle]}
+              >
+                {formatText(progressValue)}
+              </Text>
+            )}
           </View>
         ) : false}
         {children}


### PR DESCRIPTION
Currently one can only put text inside of the circle chart.
This change enables putting an element instead.
For example i wanted to put 2 lines of text inside of the circle, with this change it is now possible.