### PR TITLE
Add prop to Bar to animate only when progress is increasing

### DIFF
--- a/Bar.js
+++ b/Bar.js
@@ -15,6 +15,7 @@ const BAR_WIDTH_ZERO_POSITION = INDETERMINATE_WIDTH_FACTOR / (1 + INDETERMINATE_
 export default class ProgressBar extends Component {
   static propTypes = {
     animated: PropTypes.bool,
+    animateIncreaseOnly: PropTypes.bool,
     borderColor: PropTypes.string,
     borderRadius: PropTypes.number,
     borderWidth: PropTypes.number,
@@ -30,6 +31,7 @@ export default class ProgressBar extends Component {
 
   static defaultProps = {
     animated: true,
+    animateIncreaseOnly: false,
     borderRadius: 4,
     borderWidth: 1,
     color: 'rgba(0, 122, 255, 1)',
@@ -73,7 +75,14 @@ export default class ProgressBar extends Component {
         : Math.min(Math.max(props.progress, 0), 1)
       );
 
-      if (props.animated) {
+      if (
+        props.animated &&
+        (
+          !props.animateIncreaseOnly || (
+            props.animateIncreaseOnly && (progress > this.props.progress)
+          )
+        )
+      ) {
         Animated.spring(this.state.progress, {
           toValue: progress,
           bounciness: 0,

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ All of the props under *Properties* in addition to the following:
 |**`width`**|Full width of the progress bar. |`150`|
 |**`height`**|Height of the progress bar. |`6`|
 |**`borderRadius`**|Rounding of corners, set to `0` to disable. |`4`|
+|**`animateIncreaseOnly`**|Animate the changes to `progress` only if increasing. |`false`|
 
 ### `Progress.Circle`
 


### PR DESCRIPTION
I needed to reset the bar progress after it was complete, several times in a row, but the animation made it look very confusing (it was going back and forth).

So I added this simple prop to animate the progress change only if the new value is greater than the previous one.

Not sure about the prop naming, or if it can be useful to others, but anyway, here you go.