### PR TITLE
Add `strokeCap` prop for `Progress.Circle`

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -92,6 +92,7 @@ export class ProgressCircle extends Component {
       showsText,
       size,
       style,
+      strokeCap,
       textStyle,
       thickness,
       unfilledColor,
@@ -157,6 +158,7 @@ export class ProgressCircle extends Component {
               startAngle={0}
               endAngle={(indeterminate ? 1.8 : 2) * Math.PI}
               stroke={borderColor || color}
+              strokeCap={strokeCap}
               strokeWidth={border}
             />
           ) : false}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-progress
 
-Progress indicators and spinners for React Native using ReactART. 
+Progress indicators and spinners for React Native using ReactART.
 
 ![progress-demo](https://cloud.githubusercontent.com/assets/378279/11212043/64fb1420-8d01-11e5-9ec0-5e175a837c62.gif)
 
@@ -10,7 +10,7 @@ Progress indicators and spinners for React Native using ReactART.
 
 ### ReactART based components
 
-To use the `Pie` or `Circle` components, you need to include the ART library in your project on iOS, for android it's already included. 
+To use the `Pie` or `Circle` components, you need to include the ART library in your project on iOS, for android it's already included.
 
 #### For CocoaPod users:
 
@@ -72,6 +72,7 @@ All of the props under *Properties* in addition to the following:
 |**`formatText(progress)`**|A function returning a string to be displayed for the textual representation. |*See source*|
 |**`textStyle`**|Styles for progress text, defaults to a same `color` as circle and `fontSize` proportional to `size` prop. |*None*|
 |**`direction`**|Direction of the circle `clockwise` or `counter-clockwise` |`clockwise`|
+|**`strokeCap`**|Stroke Cap style for the circle `butt`, `square` or `round` |`butt`|
 
 ### `Progress.Pie`
 
@@ -95,14 +96,14 @@ All of the props under *Properties* in addition to the following:
 
 ## Examples
 
-* [`Example` project bundled with this module](https://github.com/oblador/react-native-progress/tree/master/Example) 
+* [`Example` project bundled with this module](https://github.com/oblador/react-native-progress/tree/master/Example)
 * [react-native-image-progress](https://github.com/oblador/react-native-image-progress)
 
 ## [Changelog](https://github.com/oblador/react-native-progress/releases)
 
 ## Thanks
 
-To [Mandarin Drummond](https://github.com/MandarinConLaBarba) for giving me the NPM name. 
+To [Mandarin Drummond](https://github.com/MandarinConLaBarba) for giving me the NPM name.
 
 ## License
 

--- a/Shapes/Arc.js
+++ b/Shapes/Arc.js
@@ -52,6 +52,7 @@ export default class Arc extends Component {
       top: PropTypes.number,
       left: PropTypes.number,
     }),
+    strokeCap: PropTypes.string,
     strokeWidth: PropTypes.number,
     direction: PropTypes.oneOf(['clockwise', 'counter-clockwise']),
   };
@@ -59,6 +60,7 @@ export default class Arc extends Component {
   static defaultProps = {
     startAngle: 0,
     offset: { top: 0, left: 0 },
+    strokeCap: 'butt',
     strokeWidth: 0,
     direction: 'clockwise',
   };
@@ -70,6 +72,7 @@ export default class Arc extends Component {
       radius,
       offset,
       direction,
+      strokeCap,
       strokeWidth,
       ...restProps
     } = this.props;
@@ -86,7 +89,7 @@ export default class Arc extends Component {
     return (
       <ART.Shape
         d={path}
-        strokeCap="butt"
+        strokeCap={strokeCap}
         strokeWidth={strokeWidth}
         {...restProps}
       />


### PR DESCRIPTION
Thank you so much for this project, its proven itself very useful.

Changes: Allows for further customization of the `Progress.Circle` by adding a `strokeCap` prop, similar to the `Progress.CircleSnail` component.