### PR TITLE
Fix style as a prop warning

### DIFF
--- a/Bar.js
+++ b/Bar.js
@@ -115,8 +115,8 @@ export default class ProgressBar extends Component {
     const innerWidth = width - (outerBorderWidth * 2);
     const containerStyle = {
       width,
-      outerBorderWidth,
-      outerBorderColor: outerBorderColor || color,
+      borderWidth: outerBorderWidth,
+      borderColor: outerBorderColor || color,
       borderRadius,
       overflow: 'hidden',
       backgroundColor: unfilledColor,

--- a/Bar.js
+++ b/Bar.js
@@ -15,9 +15,9 @@ const BAR_WIDTH_ZERO_POSITION = INDETERMINATE_WIDTH_FACTOR / (1 + INDETERMINATE_
 export default class ProgressBar extends Component {
   static propTypes = {
     animated: PropTypes.bool,
-    borderColor: PropTypes.string,
+    outerBorderColor: PropTypes.string,
     borderRadius: PropTypes.number,
-    borderWidth: PropTypes.number,
+    outerBorderWidth: PropTypes.number,
     children: PropTypes.node,
     color: PropTypes.string,
     height: PropTypes.number,
@@ -31,7 +31,7 @@ export default class ProgressBar extends Component {
   static defaultProps = {
     animated: true,
     borderRadius: 4,
-    borderWidth: 1,
+    outerBorderWidth: 1,
     color: 'rgba(0, 122, 255, 1)',
     height: 6,
     indeterminate: false,
@@ -100,9 +100,9 @@ export default class ProgressBar extends Component {
 
   render() {
     const {
-      borderColor,
+      outerBorderColor,
       borderRadius,
-      borderWidth,
+      outerBorderWidth,
       children,
       color,
       height,
@@ -112,11 +112,11 @@ export default class ProgressBar extends Component {
       ...restProps
     } = this.props;
 
-    const innerWidth = width - (borderWidth * 2);
+    const innerWidth = width - (outerBorderWidth * 2);
     const containerStyle = {
       width,
-      borderWidth,
-      borderColor: borderColor || color,
+      outerBorderWidth,
+      outerBorderColor: outerBorderColor || color,
       borderRadius,
       overflow: 'hidden',
       backgroundColor: unfilledColor,

--- a/Circle.js
+++ b/Circle.js
@@ -29,8 +29,8 @@ const styles = StyleSheet.create({
 export class ProgressCircle extends Component {
   static propTypes = {
     animated: PropTypes.bool,
-    borderColor: PropTypes.string,
-    borderWidth: PropTypes.number,
+    outerBorderColor: PropTypes.string,
+    outerBorderWidth: PropTypes.number,
     color: PropTypes.string,
     children: React.PropTypes.node,
     direction: PropTypes.oneOf(['clockwise', 'counter-clockwise']),
@@ -50,7 +50,7 @@ export class ProgressCircle extends Component {
   };
 
   static defaultProps = {
-    borderWidth: 1,
+    outerBorderWidth: 1,
     color: 'rgba(0, 122, 255, 1)',
     direction: 'clockwise',
     formatText: progress => `${Math.round(progress * 100)}%`,
@@ -80,8 +80,8 @@ export class ProgressCircle extends Component {
   render() {
     const {
       animated,
-      borderColor,
-      borderWidth,
+      outerBorderColor,
+      outerBorderWidth,
       color,
       children,
       direction,
@@ -98,7 +98,7 @@ export class ProgressCircle extends Component {
       ...restProps
     } = this.props;
 
-    const border = borderWidth || (indeterminate ? 1 : 0);
+    const border = outerBorderWidth || (indeterminate ? 1 : 0);
 
     const radius = (size / 2) - border;
     const offset = {
@@ -156,7 +156,7 @@ export class ProgressCircle extends Component {
               radius={size / 2}
               startAngle={0}
               endAngle={(indeterminate ? 1.8 : 2) * Math.PI}
-              stroke={borderColor || color}
+              stroke={outerBorderColor || color}
               strokeWidth={border}
             />
           ) : false}

--- a/Pie.js
+++ b/Pie.js
@@ -29,8 +29,8 @@ const styles = StyleSheet.create({
 export class ProgressPie extends Component {
   static propTypes = {
     animated: PropTypes.bool,
-    borderColor: PropTypes.string,
-    borderWidth: PropTypes.number,
+    outerBorderColor: PropTypes.string,
+    outerBorderWidth: PropTypes.number,
     color: PropTypes.string,
     children: PropTypes.node,
     progress: PropTypes.oneOfType([
@@ -44,7 +44,7 @@ export class ProgressPie extends Component {
   };
 
   static defaultProps = {
-    borderWidth: 1,
+    outerBorderWidth: 1,
     color: 'rgba(0, 122, 255, 1)',
     progress: 0,
     size: 40,
@@ -53,8 +53,8 @@ export class ProgressPie extends Component {
   render() {
     const {
       animated,
-      borderColor,
-      borderWidth,
+      outerBorderColor,
+      outerBorderWidth,
       children,
       color,
       progress,
@@ -70,10 +70,10 @@ export class ProgressPie extends Component {
     const Shape = animated ? AnimatedSector : Sector;
 
     const angle = animated ? Animated.multiply(progress, CIRCLE) : progress * CIRCLE;
-    const radius = (size / 2) - borderWidth;
+    const radius = (size / 2) - outerBorderWidth;
     const offset = {
-      top: borderWidth,
-      left: borderWidth,
+      top: outerBorderWidth,
+      left: outerBorderWidth,
     };
 
     return (
@@ -103,11 +103,11 @@ export class ProgressPie extends Component {
             offset={offset}
             fill={color}
           />
-          {borderWidth ? (
+          {outerBorderWidth ? (
             <Circle
               radius={size / 2}
-              stroke={borderColor || color}
-              strokeWidth={borderWidth}
+              stroke={outerBorderColor || color}
+              strokeWidth={outerBorderWidth}
             />
           ) : false}
         </Surface>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-progress
 
-Progress indicators and spinners for React Native using ReactART. 
+Progress indicators and spinners for React Native using ReactART.
 
 ![progress-demo](https://cloud.githubusercontent.com/assets/378279/11212043/64fb1420-8d01-11e5-9ec0-5e175a837c62.gif)
 
@@ -10,7 +10,7 @@ Progress indicators and spinners for React Native using ReactART.
 
 ### ReactART based components
 
-To use the `Pie` or `Circle` components, you need to include the ART library in your project on iOS, for android it's already included. 
+To use the `Pie` or `Circle` components, you need to include the ART library in your project on iOS, for android it's already included.
 
 #### For CocoaPod users:
 
@@ -47,8 +47,8 @@ import * as Progress from 'react-native-progress';
 |**`progress`**|Progress of whatever the indicator is indicating. A number between 0 and 1. |`0`|
 |**`color`**|Fill color of the indicator. |`rgba(0, 122, 255, 1)`|
 |**`unfilledColor`**|Color of the remaining progress. |*None*|
-|**`borderWidth`**|Width of outer border, set to `0` to remove. |`1`|
-|**`borderColor`**|Color of outer border. |`color`|
+|**`outerBorderWidth`**|Width of outer border, set to `0` to remove. |`1`|
+|**`outerBorderColor`**|Color of outer border. |`color`|
 
 ### `Progress.Bar`
 
@@ -95,14 +95,14 @@ All of the props under *Properties* in addition to the following:
 
 ## Examples
 
-* [`Example` project bundled with this module](https://github.com/oblador/react-native-progress/tree/master/Example) 
+* [`Example` project bundled with this module](https://github.com/oblador/react-native-progress/tree/master/Example)
 * [react-native-image-progress](https://github.com/oblador/react-native-image-progress)
 
 ## [Changelog](https://github.com/oblador/react-native-progress/releases)
 
 ## Thanks
 
-To [Mandarin Drummond](https://github.com/MandarinConLaBarba) for giving me the NPM name. 
+To [Mandarin Drummond](https://github.com/MandarinConLaBarba) for giving me the NPM name.
 
 ## License
 


### PR DESCRIPTION
Hi.
I prepared a PR in which I rename `borderColor` and `borderWidth` props by adding the `outer` suffix.
It fixes the `style as a prop warning` in React Native. (I am using 0.40.0)

![](https://api.monosnap.com/rpc/file/download?id=0waeWtwnmTqk0kbTj7eHSkCZko8WPr)