### PR TITLE
Adding Flex dynamic sizing to Progress Bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ All of the props under *Properties* in addition to the following:
 
 | Prop | Description | Default |
 |---|---|---|
-|**`width`**|Full width of the progress bar. |`150`|
-|**`height`**|Height of the progress bar. |`6`|
+|**`width`**|Full width of the progress bar. (will be ignored when using flex to fill parent space) |`150`|
+|**`height`**|Height of the progress bar. (will expand to wrap content if children components exist) |`6`|
 |**`borderRadius`**|Rounding of corners, set to `0` to disable. |`4`|
 
 ### `Progress.Circle`


### PR DESCRIPTION
Made a few changes to allow easier dynamic sizing of the progress bar

- I get the actual measured size of the layout with `onLayout`

- If it's parent is a flex container and the `flexGrow` style is used to make it fill the available space, before the progress would still be the original `width` size. I use the previous values to update the progress to fill the actual size

- Likewise, stretching the ProgressBar with the default `alignSelf: 'stretch'` would only stretch the container, not the progress. I update this value with the measured size as well.

- Because I noticed progress bars can have children, I also made some changes to make sure the content is displayed on top of the progress and also that the container view wraps the size of the content.
