### PR TITLE
Fix TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,71 +4,71 @@ declare module 'react-native-progress' {
 
 	/**
 	 * Properties for all `Progress` components.
-	 * 
+	 *
 	 * @export
-	 * @interface DetaultPropTypes
+	 * @interface DefaultPropTypes
 	 * @extends {ViewProperties}
 	 */
-  export interface DetaultPropTypes extends ViewProperties {
+  export interface DefaultPropTypes extends ViewProperties {
 		/**
 		 * Whether or not to animate changes to progress.
-		 * 
+		 *
 		 * @type {boolean}
-		 * @memberof DetaultPropTypes
+		 * @memberof DefaultPropTypes
 		 * @default true
 		 */
 		animated?: boolean
-		
+
 		/**
 		 * If set to true, the indicator will spin and progress prop will be ignored.
-		 * 
+		 *
 		 * @type {boolean}
-		 * @memberof DetaultPropTypes
+		 * @memberof DefaultPropTypes
 		 * @default false
 		 */
 		indeterminate?: boolean
-		
+
 		/**
 		 * Progress of whatever the indicator is indicating. A number between `0` and `1`
-		 * 
+		 *
 		 * @type {(0 | 1)}
-		 * @memberof DetaultPropTypes
+		 * @memberof DefaultPropTypes
 		 * @default 0
 		 */
 		progress?: number
-		
+
 		/**
 		 * Fill color of the indicator.
-		 * 
+		 *
 		 * @type {string}
-		 * @memberof DetaultPropTypes
+		 * @memberof DefaultPropTypes
 		 * @default rgba(0, 122, 255, 1)
 		 */
 		color?: string
-		
+
 		/**
 		 * Color of the remaining progress.
-		 * 
+		 *
 		 * @type {string}
-		 * @memberof DetaultPropTypes
+		 * @memberof DefaultPropTypes
 		 * @default None
 		 */
 		unfilledColor?: string
-		
+
 		/**
 		 * Width of outer border, set to `0` to remove.
-		 * 
+		 *
 		 * @type {number}
-		 * @memberof DetaultPropTypes
+		 * @memberof DefaultPropTypes
 		 * @default 1
 		 */
 		borderWidth?: number
-		
+
 		/**
 		 * Color of outer border.
-		 * 
+		 *
 		 * @type {string}
-		 * @memberof DetaultPropTypes
+		 * @memberof DefaultPropTypes
 		 * @default color
 		 */
     borderColor?: string
@@ -76,132 +76,132 @@ declare module 'react-native-progress' {
 
 	/**
 	 * Properties for `Bar` components
-	 * 
+	 *
 	 * @export
 	 * @interface BarPropTypes
-	 * @extends {DetaultPropTypes}
+	 * @extends {DefaultPropTypes}
 	 */
-  export interface BarPropTypes extends DetaultPropTypes {
+  export interface BarPropTypes extends DefaultPropTypes {
 		/**
 		 * Full width of the progress bar, set to null to use automatic flexbox sizing.
-		 * 
+		 *
 		 * @type {number}
 		 * @memberof BarPropTypes
 		 * @default 150
 		 */
 		width?: number
-		
+
 		/**
 		 * Height of the progress bar.
-		 * 
+		 *
 		 * @type {number}
 		 * @memberof BarPropTypes
 		 * @default 6
 		 */
 		height?: number
-		
+
 		/**
 		 * Rounding of corners, set to `0` to disable.
-		 * 
+		 *
 		 * @type {number}
 		 * @memberof BarPropTypes
 		 * @default 4
 		 */
 		borderRadius?: number
-		
+
 		/**
 		 * Use native driver for the animations.
-		 * 
+		 *
 		 * @type {boolean}
 		 * @memberof BarPropTypes
 		 * @default false
 		 */
 		useNativeDriver?: boolean
-		
+
 		/**
 		 * Config that is passed into the Animated function
-		 * 
+		 *
 		 * @type {{}}
 		 * @memberof BarPropTypes
 		 * @default { bounciness: 0 }
 		 */
 		animationConfig?: {}
-		
+
 		/**
 		 * Animation type to animate the progress, one of: `decay`, `timing`, `spring`
-		 * 
+		 *
 		 * @type {('decay' | 'timing' | 'spring')}
 		 * @memberof BarPropTypes
 		 * @default spring
 		 */
     animationType?: 'decay' | 'timing' | 'spring'
 	}
-	
+
 	/**
 	 * Properties for `Circle` components
-	 * 
+	 *
 	 * @export
 	 * @interface CirclePropTypes
-	 * @extends {DetaultPropTypes}
+	 * @extends {DefaultPropTypes}
 	 */
-  export interface CirclePropTypes extends DetaultPropTypes {
+  export interface CirclePropTypes extends DefaultPropTypes {
 
 		/**
 		 * Diameter of the circle.
-		 * 
+		 *
 		 * @type {number}
 		 * @memberof CirclePropTypes
 		 * @default 40
 		 */
 		size?: number
-		
+
 		/**
 		 * Thickness of the inner circle.
-		 * 
+		 *
 		 * @type {number}
 		 * @memberof CirclePropTypes
 		 * @default 3
 		 */
 		thickness?: number
-		
+
 		/**
 		 * Whether or not to show a text representation of current progress.
-		 * 
+		 *
 		 * @type {boolean}
 		 * @memberof CirclePropTypes
 		 * @default false
 		 */
 		showsText?: boolean
-		
+
 		/**
 		 * A function returning a string to be displayed for the textual representation.
-		 * 
+		 *
 		 * @memberof CirclePropTypes
 		 * @default See source
 		 */
 		formatText?: (progress: number) => void
-		
+
 		/**
 		 * Styles for progress text, defaults to a same `color` as circle and `fontSize` proportional to `size` prop.
-		 * 
+		 *
 		 * @type {string}
 		 * @memberof CirclePropTypes
 		 * @default None
 		 */
 		textStyle?: string
-		
+
 		/**
 		 * Direction of the circle `clockwise` or `counter-clockwise`.
-		 * 
+		 *
 		 * @type {('clockwise' | 'counter-clockwise')}
 		 * @memberof CirclePropTypes
 		 * @default clockwise
 		 */
 		direction?: 'clockwise' | 'counter-clockwise'
-		
+
 		/**
 		 * Stroke Cap style for the circle `butt`, `square` or `round`.
-		 * 
+		 *
 		 * @type {('butt' | 'square' | 'round')}
 		 * @memberof CirclePropTypes
 		 * @default butt
@@ -211,15 +211,15 @@ declare module 'react-native-progress' {
 
 	/**
 	 * Properties for `PiePropTypes` components
-	 * 
+	 *
 	 * @export
 	 * @interface PiePropTypes
-	 * @extends {DetaultPropTypes}
+	 * @extends {DefaultPropTypes}
 	 */
-  export interface PiePropTypes extends DetaultPropTypes {
+  export interface PiePropTypes extends DefaultPropTypes {
 		/**
 		 * Diameter of the pie.
-		 * 
+		 *
 		 * @type {number}
 		 * @memberof PiePropTypes
 		 * @default 40
@@ -229,33 +229,33 @@ declare module 'react-native-progress' {
 
 	/**
 	 * Properties for `CircleSnailPropTypes` components
-	 * 
+	 *
 	 * @export
 	 * @interface CircleSnailPropTypes
-	 * @extends {DetaultPropTypes}
+	 * @extends {DefaultPropTypes}
 	 */
-  export interface CircleSnailPropTypes extends DetaultPropTypes {
+  export interface CircleSnailPropTypes extends DefaultPropTypes {
 		/**
 		 * If the circle should animate.
-		 * 
+		 *
 		 * @type {boolean}
 		 * @memberof CircleSnailPropTypes
 		 * @default true
 		 */
-		animating: boolean
+		animating?: boolean
 
 		/**
 		 * If the circle should be removed when not animating.
-		 * 
+		 *
 		 * @type {boolean}
 		 * @memberof CircleSnailPropTypes
 		 * @default true
-		 */		
-		hidesWhenStopped: boolean
+		 */
+		hidesWhenStopped?: boolean
 
 		/**
 		 * Diameter of the circle.
-		 * 
+		 *
 		 * @type {number}
 		 * @memberof CircleSnailPropTypes
 		 * @default 40
@@ -264,16 +264,16 @@ declare module 'react-native-progress' {
 
 		/**
 		 * Color of the circle, use an array of colors for rainbow effect.
-		 * 
+		 *
 		 * @type {string}
 		 * @memberof CircleSnailPropTypes
 		 * @default rgba(0, 122, 255, 1)
 		 */
-		color: string
+		color?: string
 
 		/**
 		 * Thickness of the circle.
-		 * 
+		 *
 		 * @type {number}
 		 * @memberof CircleSnailPropTypes
 		 * @default 3
@@ -282,30 +282,30 @@ declare module 'react-native-progress' {
 
 		/**
 		 * Duration of animation.
-		 * 
+		 *
 		 * @type {number}
 		 * @memberof CircleSnailPropTypes
 		 * @default 1000
 		 */
-		duration: number
+		duration?: number
 
 		/**
 		 * Duration of spin (orbit) animation.
-		 * 
+		 *
 		 * @type {number}
 		 * @memberof CircleSnailPropTypes
 		 * @default 5000
 		 */
-		spinDuration: number
+		spinDuration?: number
 
 		/**
 		 * Stroke Cap style for the circle `butt`, `square` or `round`
-		 * 
+		 *
 		 * @type {('butt' | 'square' | 'round')}
 		 * @memberof CircleSnailPropTypes
 		 * @default round
 		 */
-		strokeCap: 'butt' | 'square' | 'round'    
+		strokeCap?: 'butt' | 'square' | 'round'
   }
 
 	export class Bar extends React.Component<BarPropTypes> {}


### PR DESCRIPTION
Spelling was off for DefaultPropTypes, and props with defaults were not denoted as optional