### PR TITLE
Use namespace import in definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'react-native-progress' {
-  import React from 'react'
+  import * as React from 'react'
   import { ViewProperties } from 'react-native'
 
 	/**


### PR DESCRIPTION
This PR changes 

```ts
import React from 'react';
```

to

```ts
import * as React from 'react'
```

`react` doesn't define a default export, so using the first version requires users of this library to enable `allowSyntheticDefaultImports`, which is potentially unsafe, since it affects typechecking but not the code emissions.

The namespace import (`import * as`) is the correct version wrt the ES2015  module spec.