### PR TITLE
feat: children for Bar chart

### DIFF
--- a/Bar.js
+++ b/Bar.js
@@ -170,8 +170,9 @@ export default class ProgressBar extends Component {
         onLayout={this.handleLayout}
         {...restProps}
       >
-        <Animated.View style={progressStyle} />
-        {children}
+        <Animated.View style={progressStyle}>
+          {children}
+        </Animated.View>
       </View>
     );
   }

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ All of the props under *Properties* in addition to the following:
 |**`useNativeDriver`**|Use native driver for the animations. |`false`|
 |**`animationConfig`**|Config that is passed into the `Animated` function. |`{ bounciness: 0 }`|
 |**`animationType`**|Animation type to animate the progress, one of: `decay`, `timing`, `spring`. |`spring`|
+|**`children`**|You can specify your own element(s) to be scaled as Bar, for example, [`<LinearGradient />`](https://github.com/react-native-community/react-native-linear-gradient) |`null`|
 
 ### `Progress.Circle`
 


### PR DESCRIPTION
With this feature, children for `<Bar />` chart could be scaled, too. Very useful for implementation of gradient progress bars with help of [`<LinearGradient />`](https://github.com/react-native-community/react-native-linear-gradient).

![image](https://user-images.githubusercontent.com/1525725/48147927-8df5ee80-e286-11e8-8eb6-86abf95be51b.png)
