### PR TITLE
Fixed a issue that Circle shows incorrectly when progress is 0.

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -32,6 +32,7 @@ export class ProgressCircle extends Component {
       PropTypes.number,
       PropTypes.instanceOf(Animated.Value),
     ]),
+    originProgress: PropTypes.number,
     rotation: PropTypes.instanceOf(Animated.Value),
     showsText: PropTypes.bool,
     size: PropTypes.number,
@@ -49,6 +50,7 @@ export class ProgressCircle extends Component {
     direction: 'clockwise',
     formatText: progress => `${Math.round(progress * 100)}%`,
     progress: 0,
+    originProgress: 0,
     showsText: false,
     size: 40,
     thickness: 3,
@@ -84,6 +86,7 @@ export class ProgressCircle extends Component {
       formatText,
       indeterminate,
       progress,
+      originProgress,
       rotation,
       showsText,
       size,
@@ -146,7 +149,7 @@ export class ProgressCircle extends Component {
           ) : (
             false
           )}
-          {!indeterminate ? (
+          {!indeterminate && originProgress > 0 ? (
             <Shape
               fill={fill}
               radius={radius}

--- a/withAnimation.js
+++ b/withAnimation.js
@@ -104,6 +104,7 @@ export default function withAnimation(WrappedComponent, indeterminateProgress) {
           progress={
             this.props.animated ? this.state.progress : this.props.progress
           }
+          originProgress={this.props.progress}
           rotation={this.state.rotation}
         />
       );


### PR DESCRIPTION
There is a problem that `Circle` shows incorrectly when `progress` is 0 and `strokeCap` is `round` or `square`.

### Sample code

```js
<Progress.Circle
  size={200}
  unfilledColor="#fff"
  progress={0}
  color="red"
  thickness={20}
  borderColor="gray"
  strokeCap="round"
/>
```

### Wrong result
![wrong-result](https://gist.githubusercontent.com/ifsnow/4ffc95a0670756e3bcd68e7b7965a61d/raw/47a40ecfa1044ebba2b0019c072f423e585e9b31/react-native-progress-wrong-result.png)

### Expected result
![expected-result](https://gist.githubusercontent.com/ifsnow/4ffc95a0670756e3bcd68e7b7965a61d/raw/47a40ecfa1044ebba2b0019c072f423e585e9b31/react-native-progress-expected-result.png)

I hope this helps.
