### PR TITLE
Added the allowFontScaling flag

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -41,6 +41,7 @@ export class ProgressCircle extends Component {
     thickness: PropTypes.number,
     unfilledColor: PropTypes.string,
     endAngle: PropTypes.number,
+    allowFontScaling: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -53,6 +54,7 @@ export class ProgressCircle extends Component {
     size: 40,
     thickness: 3,
     endAngle: 0.9,
+    allowFontScaling: true,
   };
 
   constructor(props, context) {
@@ -93,6 +95,7 @@ export class ProgressCircle extends Component {
       thickness,
       unfilledColor,
       endAngle,
+      allowFontScaling,
       ...restProps
     } = this.props;
 
@@ -196,6 +199,7 @@ export class ProgressCircle extends Component {
                 },
                 textStyle,
               ]}
+              allowFontScaling={allowFontScaling}
             >
               {formatText(progressValue)}
             </Text>


### PR DESCRIPTION
It would be fantastic if you guys could allow us to disable font scaling on demand. Right now since we can't pass the prop to the circle progress we end up with aberrations like this, in case this doesn't get merged, for anyone in a similar situation, you can override the defaultprops globally for `Text` by doing something like:

```
Text.defaultProps = Text.defaultProps || {};
Text.defaultProps.allowFontScaling = false;
```

![image](https://user-images.githubusercontent.com/4631227/54377651-dcc4f200-4685-11e9-910a-dec83386f888.png)
