### PR TITLE
Fix: Progress text sometimes does not update

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -183,7 +183,7 @@ export class ProgressCircle extends Component {
               justifyContent: 'center',
             }}
           >
-            <Animated.Text
+            <Text
               style={[
                 {
                   color,
@@ -195,7 +195,7 @@ export class ProgressCircle extends Component {
               allowFontScaling={allowFontScaling}
             >
               {formatText(progressValue)}
-            </Animated.Text>
+            </Text>
           </View>
         ) : false}
         {children}

--- a/Circle.js
+++ b/Circle.js
@@ -57,17 +57,10 @@ export class ProgressCircle extends Component {
     allowFontScaling: true,
   };
 
-  constructor(props, context) {
-    super(props, context);
-
-    this.progressValue = 0;
-  }
-
-  componentWillMount() {
+  componentDidMount() {
     if (this.props.animated) {
       this.props.progress.addListener(event => {
-        this.progressValue = event.value;
-        if (this.props.showsText || this.progressValue === 1) {
+        if (this.props.showsText || event.value === 1) {
           this.forceUpdate();
         }
       });
@@ -111,7 +104,7 @@ export class ProgressCircle extends Component {
 
     const Surface = rotation ? AnimatedSurface : ART.Surface;
     const Shape = animated ? AnimatedArc : Arc;
-    const progressValue = animated ? this.progressValue : progress;
+    const progressValue = animated ? progress._value : progress;
     const angle = animated
       ? Animated.multiply(progress, CIRCLE)
       : progress * CIRCLE;
@@ -190,7 +183,7 @@ export class ProgressCircle extends Component {
               justifyContent: 'center',
             }}
           >
-            <Text
+            <Animated.Text
               style={[
                 {
                   color,
@@ -202,11 +195,9 @@ export class ProgressCircle extends Component {
               allowFontScaling={allowFontScaling}
             >
               {formatText(progressValue)}
-            </Text>
+            </Animated.Text>
           </View>
-        ) : (
-          false
-        )}
+        ) : false}
         {children}
       </View>
     );

--- a/Circle.js
+++ b/Circle.js
@@ -104,7 +104,8 @@ export class ProgressCircle extends Component {
 
     const Surface = rotation ? AnimatedSurface : ART.Surface;
     const Shape = animated ? AnimatedArc : Arc;
-    const progressValue = animated ? progress._value : progress;
+    // eslint-disable-next-line no-underscore-dangle
+    const progressValue = animated ? progress.__getValue() : progress;
     const angle = animated
       ? Animated.multiply(progress, CIRCLE)
       : progress * CIRCLE;


### PR DESCRIPTION
I found a small bug in `Circle.js`; when I update the progress from `0` to `0.05` the progress bar grows to 5% but the text continues to display "0%". Further updates of the component do not show the problem.

# Repro

Initialise the component with:
```
<Circle
  progress={0}
  color="#564"
  size={55}
  showsText
  strokeCap="round"
  style={s.progressCircle}
/>
```

Then update it:
```
<Circle
  progress={0.05}
  color="#564"
  size={55}
  showsText
  strokeCap="round"
  style={s.progressCircle}
/>
```

# Proposed fix

It looks like the listener that is registered in `componentWillMount()` sets `this.progressValue` too late, after the component has updated. A simple solution is to stop using `this.progressValue` and instead read the internal value inside `this.props.progress` (an instance of `Animated.Value`). The race condition is therefore avoided.

# Further improvements

I'm not sure if the `componentDidMount()` listener is still useful. It looks like it was there to work around this particular bug. I left it because it may be needed in some other case I'm not aware of.

Feel free to amend the merge request.