### PR TITLE
 🏷️ Fix TypeScript for Circle component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -224,6 +224,15 @@ declare module 'react-native-progress' {
      * @default butt
      */
     strokeCap?: 'butt' | 'square' | 'round';
+
+    /**
+     * Fill color of the inner circle.
+     *
+     * @type {string}
+     * @memberof CirclePropTypes
+     * @default None
+     */
+    fill?: string;
   }
 
   /**


### PR DESCRIPTION
The TypeScript definition for the Circle component was missing the `fill` property. This pull request resolves the issue.