### PR TITLE
Change dependencies to peerDependencies to fix view registration conflict.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.11.0",
-    "prettier": "^1.16.4"
+    "prettier": "^1.16.4",
+    "prop-types": "^15.7.2",
+    "@react-native-community/art": "^1.0.3"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-react": "^7.11.0",
     "prettier": "^1.16.4"
   },
-  "dependencies": {
+  "peerDependencies": {
     "prop-types": "^15.7.2",
     "@react-native-community/art": "^1.0.3"
   },


### PR DESCRIPTION
If the host project or other libraries depend on @react-native-community/art, `Invariant Violation: Tried to register two views with the same name ARTSurfaceView` error occurs. (for example #176)
I think the dependencies should be specified in the host project's package.json.
