### PR TITLE
[BUGFIX] Upgrade @react-native-community/art 

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "@react-native-community/art": "^1.0.3"
+    "@react-native-community/art": "^1.1.2"
   },
   "typings": "index.d.ts"
 }


### PR DESCRIPTION
ART breaking in RN 0.62.rc-0.

`error: Error: Unable to resolve module `react-native/Libraries/vendor/core/merge` from `node_modules/react-native-progress/node_modules/@react-native-community/art/lib/ClippingRectangle.js`: react-native/Libraries/vendor/core/merge could not be found within the project.`

Original issue: [#48](https://github.com/react-native-community/art/issues/48)