### PR TITLE
fix: add props useNativeDriver in CircleSnail (updated)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "arrowParens": "avoid",
   "singleQuote": true,
   "trailingComma": "es5"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "arrowParens": "avoid",
   "singleQuote": true,
   "trailingComma": "es5"
 }

--- a/CircleSnail.js
+++ b/CircleSnail.js
@@ -26,6 +26,7 @@ export default class CircleSnail extends Component {
     style: PropTypes.any,
     thickness: PropTypes.number,
     strokeCap: PropTypes.string,
+    useNativeDriver: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -36,6 +37,7 @@ export default class CircleSnail extends Component {
     size: 40,
     thickness: 3,
     strokeCap: 'round',
+    useNativeDriver: false,
   };
 
   constructor(props) {
@@ -74,12 +76,14 @@ export default class CircleSnail extends Component {
         duration: this.props.duration || 1000,
         isInteraction: false,
         easing: Easing.inOut(Easing.quad),
+        useNativeDriver: this.props.useNativeDriver,
       }),
       Animated.timing(this.state.endAngle, {
         toValue: -MAX_ARC_ANGLE * iteration,
         duration: this.props.duration || 1000,
         isInteraction: false,
         easing: Easing.inOut(Easing.quad),
+        useNativeDriver: this.props.useNativeDriver,
       }),
     ]).start(endState => {
       if (endState.finished) {

--- a/CircleSnail.js
+++ b/CircleSnail.js
@@ -103,6 +103,7 @@ export default class CircleSnail extends Component {
       duration: this.props.spinDuration || 5000,
       easing: Easing.linear,
       isInteraction: false,
+      useNativeDriver: this.props.useNativeDriver,
     }).start(endState => {
       if (endState.finished) {
         this.state.rotation.setValue(0);


### PR DESCRIPTION
From RN 0.62, we have lot of warnings about useNativeDriver

> Animated: useNativeDriver was not specified. This is a required option and must be explicitly set to true or `false

Updated for #198 

Thanks @dimbslmh 