### PR TITLE
Add direction prop to typings of CircleSnail

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -350,6 +350,15 @@ declare module 'react-native-progress' {
      * @default round
      */
     strokeCap?: 'butt' | 'square' | 'round';
+
+    /**
+     * Direction in which the circle spins, either "clockwise" or "counter-clockwise" (default).
+     *
+     * @type {('clockwise' | 'counter-clockwise')}
+     * @memberof CircleSnailPropTypes
+     * @default counter-clockwise
+     */
+    direction?: 'clockwise' | 'counter-clockwise';
   }
 
   export class Bar extends React.Component<BarPropTypes> {}


### PR DESCRIPTION
CircleSnail accepts a `direction` property [see here](https://github.com/oblador/react-native-progress/blob/master/CircleSnail.js#L21). This change adds TS support for the property.