### PR TITLE
Adding custom progress style prop for Bar progress component

### DIFF
--- a/Bar.js
+++ b/Bar.js
@@ -25,6 +25,7 @@ export default class ProgressBar extends Component {
     useNativeDriver: PropTypes.bool,
     animationConfig: PropTypes.object,
     animationType: PropTypes.oneOf(['decay', 'timing', 'spring']),
+    progressCustomStyle: PropTypes.any
   };
 
   static defaultProps = {
@@ -124,6 +125,7 @@ export default class ProgressBar extends Component {
       children,
       color,
       height,
+      progressCustomStyle,
       style,
       unfilledColor,
       width,
@@ -140,6 +142,7 @@ export default class ProgressBar extends Component {
       backgroundColor: unfilledColor,
     };
     const progressStyle = {
+      ...progressCustomStyle,
       backgroundColor: color,
       height,
       transform: [


### PR DESCRIPTION
- Adding the ability to customise the progress inner-view's styles for the Bar progress component.

Before this PR, only the outer container styles could be customised (height, borderRadius etc) with no option to customise the inner <Animated.View element. 

My use-case is I need spacing between the outer-container, and the inner <Animated.View and a border radius on both elements. Currently I can do:
```
<Progress.Bar borderWidth={2} height={10} borderRadius={20} borderColor={'#FFF'} color={'#FFF'} progress={0.3} width={(window.width) * 0.6} style={{ padding: 4, borderRadius: 60 }} />
```

However since there's no way to access the inner view's styles, I can't set the border radius style of the inner element.

![image](https://user-images.githubusercontent.com/3890344/88489934-ac86a680-cf8f-11ea-983b-c1bc43cdc29f.png) 

This PR adds the `progressCustomStyle` prop to allow customisation of the inner `<Animated.View` styles.
