### PR TITLE
Move `@react-native-community/art` to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,13 @@
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.11.0",
-    "prettier": "^1.16.4"
+    "prettier": "^1.16.4",
+    "@react-native-community/art": "^1.1.2"
   },
   "dependencies": {
-    "prop-types": "^15.7.2",
+    "prop-types": "^15.7.2"
+  },
+  "peerDependencies": {
     "@react-native-community/art": "^1.1.2"
   },
   "typings": "index.d.ts"


### PR DESCRIPTION
`@react-native-community/art` is a project with native code and must be
linked into host application either manually or with autolinking.

Autolinking for a package only works as long as package is mentioned in
`package.json` of host application.

This looks like a case for `peerDependencies` since this field is intended
for a situaions where some package has to be installed separately in
final `package.json` and not fetched automatically.

Also keep it in `devDependencies` for development purposes of
`react-native-progress` itself.