### PR TITLE
add overriding default prop alignSelf: 'center'

### DIFF
--- a/CircleSnail.js
+++ b/CircleSnail.js
@@ -150,6 +150,7 @@ export default class CircleSnail extends Component {
         style={[
           style,
           {
+            alignSelf: 'center',
             backgroundColor: 'transparent',
             overflow: 'hidden',
             transform: [


### PR DESCRIPTION
this should prevent the snail from running circles around the screen

#228