### PR TITLE
Fixing black color fill for react-native-web and showing text percentage of filled circle.

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -168,6 +168,7 @@ export class ProgressCircle extends Component {
           )}
           {border ? (
             <Arc
+              fill={fill}
               radius={size / 2}
               startAngle={0}
               endAngle={(indeterminate ? endAngle * 2 : 2) * Math.PI}
@@ -203,7 +204,7 @@ export class ProgressCircle extends Component {
               ]}
               allowFontScaling={allowFontScaling}
             >
-              {formatText(progressValue)}
+              {progress ? formatText(progress._value) : this.forceUpdate()}
             </Text>
           </View>
         ) : (


### PR DESCRIPTION
This fill={fill} will change the color inside the circle for react-native-web and we need to pass fill='some color' from the frontend. This text change will show the correct percentage of the filled circle.