### PR TITLE
add: unfilledEndAngle prop to Circle.js, for dynamic instead of const…

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -42,6 +42,7 @@ export class ProgressCircle extends Component {
     thickness: PropTypes.number,
     unfilledColor: PropTypes.string,
     endAngle: PropTypes.number,
+    unfilledEndAngle: PropTypes.number,
     allowFontScaling: PropTypes.bool,
   };
 
@@ -55,6 +56,7 @@ export class ProgressCircle extends Component {
     size: 40,
     thickness: 3,
     endAngle: 0.9,
+    unfilledEndAngle: 0.9,
     allowFontScaling: true,
   };
 
@@ -96,6 +98,7 @@ export class ProgressCircle extends Component {
       thickness,
       unfilledColor,
       endAngle,
+      unfilledEndAngle,
       allowFontScaling,
       ...restProps
     } = this.props;
@@ -116,6 +119,9 @@ export class ProgressCircle extends Component {
     const angle = animated
       ? Animated.multiply(progress, CIRCLE)
       : progress * CIRCLE;
+    const endUnfilledAngleValue = animated
+      ? Animated.multiply(unfilledEndAngle, CIRCLE)
+      : unfilledEndAngle * CIRCLE;
 
     return (
       <View style={[styles.container, style]} {...restProps}>
@@ -143,7 +149,7 @@ export class ProgressCircle extends Component {
               radius={radius}
               offset={offset}
               startAngle={angle}
-              endAngle={CIRCLE}
+              endAngle={unfilledEndAngle >= progress._value ? endUnfilledAngleValue : angle}
               direction={direction}
               stroke={unfilledColor}
               strokeWidth={thickness}


### PR DESCRIPTION
I was looking to use Progress.Circle as a semi-circle loader, however it seemed that the unfilled portion of the Circle.js component is always a constant of `const CIRCLE = Math.PI * 2`. I thought I'd contribute a new prop that allows users to dynamically set the end angle of the unfilled portion of the circle with the `unfilledEndAngle` prop. This would allow users to make a semi-circle that's unfilled.

It's written basically the same exact way as the `endAngle` prop.

This also makes sure no shapes are shown if `unfilledEndAngle` is less than or equal to the current `startAngle` of the `<Shape  />` component inside Circle.js. (Can be checked by turning the `color` prop to `rgba(0,0,0,0)`)