### PR TITLE
add: alwaysUseEndAngle prop to Circle.js

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -41,6 +41,7 @@ export class ProgressCircle extends Component {
     textStyle: PropTypes.any,
     thickness: PropTypes.number,
     unfilledColor: PropTypes.string,
+    alwaysUseEndAngle: PropTypes.bool,
     endAngle: PropTypes.number,
     allowFontScaling: PropTypes.bool,
   };
@@ -54,6 +55,7 @@ export class ProgressCircle extends Component {
     showsText: false,
     size: 40,
     thickness: 3,
+    alwaysUseEndAngle: false,
     endAngle: 0.9,
     allowFontScaling: true,
   };
@@ -95,6 +97,7 @@ export class ProgressCircle extends Component {
       textStyle,
       thickness,
       unfilledColor,
+      alwaysUseEndAngle,
       endAngle,
       allowFontScaling,
       ...restProps
@@ -170,7 +173,7 @@ export class ProgressCircle extends Component {
             <Arc
               radius={size / 2}
               startAngle={0}
-              endAngle={(indeterminate ? endAngle * 2 : 2) * Math.PI}
+              endAngle={(indeterminate ? endAngle * 2 : alwaysUseEndAngle ? endAngle * 2 : 2) * Math.PI}
               stroke={borderColor || color}
               strokeCap={strokeCap}
               strokeWidth={border}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ All of the props under _Properties_ in addition to the following:
 | Prop                       | Description                                                                                                                  | Default            |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | **`size`**                 | Diameter of the circle.                                                                                                      | `40`               |
+| **`alwaysUseEndAngle`**             | endAngle, by default, is only used when `indeterminate` is  `true`. This prop ensures endAngle is always used | `false`              |
 | **`endAngle`**             | Determines the endAngle of the circle. A number between `0` and `1`. The final endAngle would be the number multiplied by 2π | `0.9`              |
 | **`thickness`**            | Thickness of the inner circle.                                                                                               | `3`                |
 | **`showsText`**            | Whether or not to show a text representation of current progress.                                                            | `false`            |


### PR DESCRIPTION
I noticed in Circle.js that `endAngle` is only used when `indeterminate` is `true`. I figured there is a reason for this, so I decided to add another prop called `alwaysUseEndAngle`. Which enables `endAngle` whether the loader is indeterminate or not.

Also, I'm not sure if you'd like this added to the README or not, I'm assuming you do and I did so in this PR, but you never know! so let me know