### PR TITLE
Added 'fill' option to Circle.Snail and default fill option for Circle components

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -49,13 +49,14 @@ export class ProgressCircle extends Component {
     borderWidth: 1,
     color: 'rgba(0, 122, 255, 1)',
     direction: 'clockwise',
-    formatText: progress => `${Math.round(progress * 100)}%`,
+    formatText: (progress) => `${Math.round(progress * 100)}%`,
     progress: 0,
     showsText: false,
     size: 40,
     thickness: 3,
     endAngle: 0.9,
     allowFontScaling: true,
+    fill: 'transparent',
   };
 
   constructor(props, context) {
@@ -66,7 +67,7 @@ export class ProgressCircle extends Component {
 
   componentDidMount() {
     if (this.props.animated) {
-      this.props.progress.addListener(event => {
+      this.props.progress.addListener((event) => {
         this.progressValue = event.value;
         if (this.props.showsText || this.progressValue === 1) {
           this.forceUpdate();

--- a/CircleSnail.js
+++ b/CircleSnail.js
@@ -27,6 +27,7 @@ export default class CircleSnail extends Component {
     thickness: PropTypes.number,
     strokeCap: PropTypes.string,
     useNativeDriver: PropTypes.bool,
+    fill: PropTypes.string,
   };
 
   static defaultProps = {
@@ -38,6 +39,7 @@ export default class CircleSnail extends Component {
     thickness: 3,
     strokeCap: 'round',
     useNativeDriver: false,
+    fill: 'transparent',
   };
 
   constructor(props) {
@@ -85,7 +87,7 @@ export default class CircleSnail extends Component {
         easing: Easing.inOut(Easing.quad),
         useNativeDriver: this.props.useNativeDriver,
       }),
-    ]).start(endState => {
+    ]).start((endState) => {
       if (endState.finished) {
         if (Array.isArray(this.props.color)) {
           this.setState({
@@ -104,7 +106,7 @@ export default class CircleSnail extends Component {
       easing: Easing.linear,
       isInteraction: false,
       useNativeDriver: this.props.useNativeDriver,
-    }).start(endState => {
+    }).start((endState) => {
       if (endState.finished) {
         this.state.rotation.setValue(0);
         this.spin();
@@ -163,7 +165,7 @@ export default class CircleSnail extends Component {
           },
         ]}
       >
-        <Svg width={size} height={size}>
+        <Svg width={size} height={size} fill={fill}>
           <AnimatedArc
             direction={
               direction === 'counter-clockwise'

--- a/CircleSnail.js
+++ b/CircleSnail.js
@@ -131,6 +131,7 @@ export default class CircleSnail extends Component {
       style,
       thickness,
       strokeCap,
+      fill,
       ...restProps
     } = this.props;
 


### PR DESCRIPTION
Added 'fill' option to Circle.Snail to have control over fill property. (Default is transparent)

Also added fill:'transparent' to Circle components' default props to have transparent fill on default.