### PR TITLE
Pass fill property to the Arc component

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -168,6 +168,7 @@ export class ProgressCircle extends Component {
           )}
           {border ? (
             <Arc
+              fill={fill}
               radius={size / 2}
               startAngle={0}
               endAngle={(indeterminate ? endAngle * 2 : 2) * Math.PI}


### PR DESCRIPTION
The fill property wasn't being passed onwards in one of the three rendering cases, causing it to render with a default black fill.

Passing it along allows the fill to be overridden by the caller.