### PR TITLE
Support for Arch Progress

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -34,6 +34,7 @@ export class ProgressCircle extends Component {
       PropTypes.instanceOf(Animated.Value),
     ]),
     rotation: PropTypes.instanceOf(Animated.Value),
+    rotationStatic: PropTypes.number,
     showsText: PropTypes.bool,
     size: PropTypes.number,
     style: PropTypes.any,

--- a/Circle.js
+++ b/Circle.js
@@ -43,6 +43,7 @@ export class ProgressCircle extends Component {
     unfilledColor: PropTypes.string,
     endAngle: PropTypes.number,
     allowFontScaling: PropTypes.bool,
+    archPercentage: PropTypes.number,
   };
 
   static defaultProps = {
@@ -55,6 +56,7 @@ export class ProgressCircle extends Component {
     size: 40,
     thickness: 3,
     endAngle: 0.9,
+    archPercentage: 1,
     allowFontScaling: true,
   };
 
@@ -96,12 +98,14 @@ export class ProgressCircle extends Component {
       thickness,
       unfilledColor,
       endAngle,
+      archPercentage,
       allowFontScaling,
       ...restProps
     } = this.props;
 
     const border = borderWidth || (indeterminate ? 1 : 0);
 
+    const circle = CIRCLE * archPercentage;
     const radius = size / 2 - border;
     const offset = {
       top: border,
@@ -114,8 +118,8 @@ export class ProgressCircle extends Component {
     const Shape = animated ? AnimatedArc : Arc;
     const progressValue = animated ? this.progressValue : progress;
     const angle = animated
-      ? Animated.multiply(progress, CIRCLE)
-      : progress * CIRCLE;
+      ? Animated.multiply(progress, circle)
+      : progress * circle;
 
     return (
       <View style={[styles.container, style]} {...restProps}>
@@ -143,7 +147,7 @@ export class ProgressCircle extends Component {
               radius={radius}
               offset={offset}
               startAngle={angle}
-              endAngle={CIRCLE}
+              endAngle={circle}
               direction={direction}
               stroke={unfilledColor}
               strokeWidth={thickness}

--- a/Circle.js
+++ b/Circle.js
@@ -90,6 +90,7 @@ export class ProgressCircle extends Component {
       indeterminate,
       progress,
       rotation,
+      rotationStatic,
       showsText,
       size,
       style,
@@ -126,7 +127,7 @@ export class ProgressCircle extends Component {
         <Surface
           width={size}
           height={size}
-          style={
+          style={[
             indeterminate && rotation
               ? {
                   transform: [
@@ -138,8 +139,11 @@ export class ProgressCircle extends Component {
                     },
                   ],
                 }
-              : undefined
-          }
+              : undefined,
+            rotationStatic ? {
+              transform: [{ rotate: `${rotationStatic}rad` }]
+            } : undefined
+          ]}
         >
           {unfilledColor && progressValue !== 1 ? (
             <Shape

--- a/Circle.js
+++ b/Circle.js
@@ -106,7 +106,7 @@ export class ProgressCircle extends Component {
 
     const border = borderWidth || (indeterminate ? 1 : 0);
 
-    const circle = CIRCLE * archPercentage;
+    const circleAngle = CIRCLE * archPercentage;
     const radius = size / 2 - border;
     const offset = {
       top: border,
@@ -119,8 +119,8 @@ export class ProgressCircle extends Component {
     const Shape = animated ? AnimatedArc : Arc;
     const progressValue = animated ? this.progressValue : progress;
     const angle = animated
-      ? Animated.multiply(progress, circle)
-      : progress * circle;
+      ? Animated.multiply(progress, circleAngle)
+      : progress * circleAngle;
 
     return (
       <View style={[styles.container, style]} {...restProps}>
@@ -151,7 +151,7 @@ export class ProgressCircle extends Component {
               radius={radius}
               offset={offset}
               startAngle={angle}
-              endAngle={circle}
+              endAngle={circleAngle}
               direction={direction}
               stroke={unfilledColor}
               strokeWidth={thickness}

--- a/index.d.ts
+++ b/index.d.ts
@@ -252,6 +252,15 @@ declare module 'react-native-progress' {
      * @default 1
      */
     archPercentage?: number
+
+    /**
+     * Static amount in radians to rotate the circle
+     * 
+     * @type {number}
+     * @memberof CirclePropTypes
+     * @default None
+     */
+    rotationStatic?: number
     }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -242,6 +242,16 @@ declare module 'react-native-progress' {
      * @default 0.9
      */
      endAngle?: number;
+
+
+    /**
+     * A percentage of the circle to render. Value less than 1 renders an arc
+     * 
+     * @type {number}
+     * @memberof CirclePropTypes
+     * @default 1
+     */
+    archPercentage?: number
     }
 
   /**


### PR DESCRIPTION
Add 2 props to allow fine control over the shape of Circle Progress.

| Prop | Description | Default |
| - | - | - |
| archPercentage | Value from 0-1 which is a percentage of the circle to render. eg. 0.75 will create an arch of 270° | 1 |
| rotationStatic | Value in radians to rotate the circle. Static rotation that is not animated | undefined |


Here's a short video showing an example of this. Arch progress indicator

https://user-images.githubusercontent.com/81269890/220799477-0c7f3433-96bf-4273-a60a-61cb7bceb99d.mp4

