### PR TITLE
fix: black circle appearing while using `Circle` & `Pie`

### DIFF
--- a/Circle.js
+++ b/Circle.js
@@ -122,6 +122,7 @@ export class ProgressCircle extends Component {
         <Surface
           width={size}
           height={size}
+          fill="none"
           style={
             indeterminate && rotation
               ? {
@@ -168,6 +169,7 @@ export class ProgressCircle extends Component {
           )}
           {border ? (
             <Arc
+              fill={fill}
               radius={size / 2}
               startAngle={0}
               endAngle={(indeterminate ? endAngle * 2 : 2) * Math.PI}

--- a/Pie.js
+++ b/Pie.js
@@ -75,6 +75,7 @@ export class ProgressPie extends Component {
         <Surface
           width={size}
           height={size}
+          fill="none"
           style={
             rotation
               ? {


### PR DESCRIPTION
Add `fill="none"` to `Surface` used in both `Circle` and `Pie`. Pass the `fill` prop from `Circle` to `Arc`.