### PR TITLE
This commit solves the issue 234 as to CircleSnail.

### DIFF
--- a/CircleSnail.js
+++ b/CircleSnail.js
@@ -165,6 +165,7 @@ export default class CircleSnail extends Component {
       >
         <Svg width={size} height={size}>
           <AnimatedArc
+            fill="transparent"
             direction={
               direction === 'counter-clockwise'
                 ? 'clockwise'


### PR DESCRIPTION
The CircleSnail component was rendering with a black fill. The solution was to set AnimatedArc's fill prop to transparent.
Tested in:
Android 10
React Native 0.72.4
create-expo-app@2.0.3
react-native-svg@13.9.0

The issue post: https://github.com/oblador/react-native-progress/issues/234